### PR TITLE
Do not save diff output in temporary file

### DIFF
--- a/backport.py
+++ b/backport.py
@@ -11,24 +11,34 @@ import tempfile
 
 class System:
     @staticmethod
-    def run(command: str) -> subprocess.CompletedProcess:
-        return subprocess.run(command, shell=True, capture_output=True)
+    def diff(before: str, after: str) -> subprocess.CompletedProcess:
+        return subprocess.run(f'diff {before} {after}', shell=True, capture_output=True)
 
     @staticmethod
-    def diff(before: str, after: str, patch: str) -> subprocess.CompletedProcess:
-        return System.run(f'diff {before} {after} > {patch}')
-
-    @staticmethod
-    def patch(target: str, patch: str, reject: str) -> subprocess.CompletedProcess:
-        return System.run(f'patch -f -r {reject} {target} {patch}')
+    def patch(target: str, patch_data: bytes, reject: str) -> subprocess.CompletedProcess:
+        pipe = subprocess.Popen(
+            f'patch -f -r {reject} {target}',
+            shell=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = pipe.communicate(input=patch_data)
+        return subprocess.CompletedProcess(
+            ['patch', '-f', '-r', reject, target],
+            returncode=pipe.returncode,
+            stdout=stdout,
+            stderr=stderr
+        )
     
     @staticmethod
     def read_lines(path: str) -> List[str]:
         with open(path) as f:
             return f.readlines()
 
-def get_patch_hunks(patch_file: str) -> Dict[id, Hunk]:
-    return {hunk.id: hunk for hunk in formats.parse_diff(System.read_lines(patch_file))}
+def get_patch_hunks(patch_data: bytes) -> Dict[id, Hunk]:
+    lines = patch_data.decode('utf-8').rstrip('\n').split('\n')
+    return {hunk.id: hunk for hunk in formats.parse_diff(lines)}
 
 def update_rejected_hunks(hunks: Dict[int, Hunk], reject_file: str):
     for hunk in formats.parse_reject(System.read_lines(reject_file)):
@@ -46,14 +56,14 @@ def merge(before: str, after: str, target: str) -> Dict[int, Hunk]:
     with tempfile.TemporaryDirectory() as temp_dir:
         hunks = None
     
-        patch_file = os.path.join(temp_dir, 'diff.patch')
-        diff = System.diff(before, after, patch_file)
+        diff = System.diff(before, after)
         if diff.returncode > 1:
             raise RuntimeError(f'Failed to compute difference between {before} and {after}')
-        hunks = get_patch_hunks(patch_file)
+        patch_data = diff.stdout
+        hunks = get_patch_hunks(patch_data)
 
         reject_file = os.path.join(temp_dir, 'reject')
-        patch = System.patch(target, patch_file, reject_file)
+        patch = System.patch(target, patch_data, reject_file)
         if patch.returncode == 2:
             raise RuntimeError(f'Error occurred while patching the target: {patch.stderr}') 
 

--- a/backport.py
+++ b/backport.py
@@ -37,7 +37,7 @@ class System:
             return f.readlines()
 
 def get_patch_hunks(patch_data: bytes) -> Dict[id, Hunk]:
-    lines = patch_data.decode('utf-8').rstrip('\n').split('\n')
+    lines = list(filter(None, patch_data.decode('utf-8').split('\n')))
     return {hunk.id: hunk for hunk in formats.parse_diff(lines)}
 
 def update_rejected_hunks(hunks: Dict[int, Hunk], reject_file: str):

--- a/formats.py
+++ b/formats.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Tuple, Dict
 from re import compile as regex
+from typing import List, Optional, Tuple, Dict
 
 @dataclass
 class Chunk:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
-import pytest
 from unittest.mock import Mock, MagicMock
+import pytest
 
 @pytest.fixture
 def mock_system(monkeypatch):
     system = Mock()
     system.read_lines.return_value = []
-    system.diff.return_value.returncode = 1
+    system.diff.return_value = Mock(returncode=1, stdout=b'')
     system.patch.return_value.returncode = 0
     monkeypatch.setattr('backport.System', system)
     return system

--- a/tests/test_diff_format.py
+++ b/tests/test_diff_format.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 import pytest
 import sys
-from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.absolute()))
 from unittest.mock import Mock
 import formats

--- a/tests/test_hunks.py
+++ b/tests/test_hunks.py
@@ -1,9 +1,9 @@
+from pathlib import Path
 import pytest
 import sys
-from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.absolute()))
-from unittest.mock import Mock
 from formats import Hunk, Chunk, ChangeType
+from unittest.mock import Mock
 
 def test_id_is_source_begin():
     hunk = Hunk(type=ChangeType.CHANGED, source=Chunk(begin=1, end=2), destination=Chunk(begin=3, end=4))

--- a/tests/test_reject_format.py
+++ b/tests/test_reject_format.py
@@ -1,6 +1,6 @@
+from pathlib import Path
 import pytest
 import sys
-from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.absolute()))
 from unittest.mock import Mock
 import formats


### PR DESCRIPTION
These changes reflect alternative approach of passing the output of `diff` utility to its counterpart `patch` via retrieving its output and piping back to `patch`.